### PR TITLE
Major Array manipulations and minor braces change.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
 		"es6": true
 	},
 	"parserOptions": {
-		"ecmaVersion": 2019
+		"ecmaVersion": "latest"
 	},
 	"rules": {
 		"brace-style": ["error", "stroustrup", { "allowSingleLine": true }],

--- a/src/events.js
+++ b/src/events.js
@@ -1,6 +1,5 @@
 const send = require(`${__dirname}/util/send`);
 
-
 /**
  * Handles the messageUpdate event
  *
@@ -11,36 +10,29 @@ const send = require(`${__dirname}/util/send`);
  * @returns {Promise<void>}
 **/
 const messageUpdate = async (oldMessage, newMessage, object) => {
-	if (oldMessage === undefined || newMessage == undefined || !oldMessage.mentions || !newMessage.mentions) {
-		throw new Error('Expected parameters \'oldMessage\', \'newMessage\' at position 1, 2');
-	}
-	if(oldMessage.author.bot || oldMessage.mentions.members.size == 0 && oldMessage.mentions.roles.size == 0) {
-		return false;
-	}
+	/*
+	=> Optional Chaining
+	=> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
+	*/
+	if (!oldMessage?.mentions || !newMessage?.mentions) throw new Error('Expected parameters \'oldMessage\', \'newMessage\' at position 1, 2');
 
-	let newArray = []; let oldArray = [];
-	oldMessage.mentions.members.forEach((member) => {
-		if(!member.user.bot && member.id != oldMessage.author.id) {
-			oldArray.push(`${member}`);
-		}
+	if (oldMessage.author.bot || oldMessage.mentions.members.size === 0 && oldMessage.mentions.roles.size === 0) return false;
+
+
+	let oldArray = oldMessage.mentions.members.map((member) => {
+		if (!member.user.bot && member.id != oldMessage.author.id) return member;
 	});
-	newMessage.mentions.members.forEach((member) => {
-		if(!member.user.bot && member.id != newMessage.author.id) {
-			newArray.push(`${member}`);
-		}
+
+	let newArray = newMessage.mentions.members.map((member) => {
+		if (!member.user.bot && member.id != newMessage.author.id) return member;
 	});
-	oldMessage.mentions.roles.forEach((role) => oldArray.push(`${role}`));
-	newMessage.mentions.roles.forEach((role) => newArray.push(`${role}`));
 
-	let mentions = [];
-	for(const mention of oldArray) {
-		if(!newArray.includes(mention)) {
-			mentions.push(mention);
-		}
-	}
+	oldArray = oldMessage.mentions.roles.concat(oldArray);
+	newArray = newMessage.mentions.roles.concat(newArray);
 
-	if(mentions == []) { return false; }
-	return await send(object, newMessage, mentions.join(', '));
+	let mentions = oldArray.filter((member) => !newArray.includes(member));
+
+	if (mentions.length > 1) return await send(object, newMessage, mentions.join(', '));
 };
 
 
@@ -54,23 +46,16 @@ const messageUpdate = async (oldMessage, newMessage, object) => {
 **/
 const messageDelete = async (message, object) => {
 
-	if(message === undefined || !message.mentions) {
-		throw new Error('Expected parameter \'message\' at position 1');
-	}
-	if(message.author.bot || message.mentions.members.size == 0 && message.mentions.roles.size == 0) {
-		return false;
-	}
+	if (!message?.mentions) throw new Error('Expected parameter \'message\' at position 0');
 
-	let mentions = [];
+	if (message.author.bot || message.mentions.members.size == 0 && message.mentions.roles.size == 0) return false;
 
-	message.mentions.members.forEach((member) => {
-		if(!member.user.bot && member.id != message.author.id) {
-			mentions.push(member);
-		}
+
+	let mentions = message.mentions.members.map((member) => {
+		if (!member.user.bot && member.id != message.author.id) return member;
 	});
 	message.mentions.roles.forEach((role) => mentions.push(role));
-
-	if(mentions == []) { return false; }
+	if (mentions.length < 1) return false;
 	return await send(object, message, mentions.join(', '));
 };
 

--- a/src/events.js
+++ b/src/events.js
@@ -10,10 +10,7 @@ const send = require(`${__dirname}/util/send`);
  * @returns {Promise<void>}
 **/
 const messageUpdate = async (oldMessage, newMessage, object) => {
-	/*
-	=> Optional Chaining
-	=> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
-	*/
+	
 	if (!oldMessage?.mentions || !newMessage?.mentions) throw new Error('Expected parameters \'oldMessage\', \'newMessage\' at position 1, 2');
 
 	if (oldMessage.author.bot || oldMessage.mentions.members.size === 0 && oldMessage.mentions.roles.size === 0) return false;

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,9 @@ const events = require(`${__dirname}/events`);
 **/
 const detector = async (event, ...args) => {
 
-	if(event && events[event]) {
-		return await events[event](...args);
-	}
+	if (!event || !events[event]) throw new Error('Expected parameter \'event\' at position 0');
+	return await events[event](...args);
 
-	throw new Error('Expected parameter \'Event\' at position 0');
 };
 
 module.exports = { detector };

--- a/src/util/ignore.js
+++ b/src/util/ignore.js
@@ -14,22 +14,22 @@ const ignore = ({ permissions, roles, channels, users }, message) => {
 
 	if((permissions && Array.isArray(permissions)) && result == false) {
 		permissions.forEach((perm) => {
-			if(message.member.permissions.has(perm)) { result = true; }
+			if(message.member.permissions.has(perm)) result = true;
 		});
 	}
 
 	if((roles && Array.isArray(roles)) && result == false) {
 		roles.forEach((role) => {
-			if (message.member.roles.cache.has(role)) { result = true; }
+			if (message.member.roles.cache.has(role)) result = true;
 		});
 	}
 
 	if((channels && Array.isArray(channels)) && result == false) {
-		if(channels.includes(message.channel.id)) { return true; }
+		if(channels.includes(message.channel.id)) return true;
 	}
 
 	if((users && Array.isArray(users)) && result == false) {
-		if(users.includes(message.author.id)) { return true; }
+		if(users.includes(message.author.id)) return true;
 	}
 
 	return result;

--- a/src/util/send.js
+++ b/src/util/send.js
@@ -41,11 +41,8 @@ const custom = (object, message) => {
 **/
 const send = async (object, message, mentions) => {
 
-	if(object && object.ignore) {
-		if(ignore(object.ignore, message) == true) {
-			return false;
-		}
-	}
+	if(object && object.ignore && ignore(object.ignore, message) === true) return false;
+
 	const { title, color, footer, channel } = custom(object, message);
 
 	const embed = {


### PR DESCRIPTION
## Overview
Change of certain array manipulations methods for better efficiency and remove unnecessary `{ }` braces

**Provide a general overview of this PR:**
- Updated files under the `src/` directory
- Bumped `.eslintrc.json` ecmaVersion from 2019 to "latest"

## General Information
1. **Does it solve a bug?** 

     No

2. **What changes have you made?** 
- Updated files under the `src/` directory
- Bumped `.eslintrc.json` ecmaVersion from 2019 to "latest"
3. **What alternatives have you tried?**
- Use of `.filter` instead of `forEach` and `for of` loops
- Use of `.concat` to merge/append arrays
- Use of `.map` to execute functions on each item in an array